### PR TITLE
mark deleted values with a special tombstone value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 venv/
 .DS_Store
 *.db
+.pytest_cache*

--- a/src/custom_types.py
+++ b/src/custom_types.py
@@ -1,6 +1,8 @@
 from typing import Union
 
-KeyType = Union[str, int, bytes]
+TOMBSTONE = 0xDEADBEE
+
+KeyType = Union[str, int, bytes, float]
 ValueType = Union[str, int, bytes, float]
 
 assert isinstance("name", KeyType)
@@ -12,3 +14,4 @@ assert isinstance("Joe", ValueType)
 assert isinstance(3, ValueType)
 assert isinstance(3.14, ValueType)
 assert isinstance(b"World!", ValueType)
+assert isinstance(TOMBSTONE, ValueType)

--- a/src/disk_store.py
+++ b/src/disk_store.py
@@ -3,7 +3,7 @@ import os
 import zlib
 from os import path, fsync
 from src.utils import validate_kv
-from src.custom_types import KeyType, ValueType
+from src.custom_types import KeyType, ValueType, TOMBSTONE
 from src.format import (
     KVEntry,
     KVHeader,
@@ -34,25 +34,11 @@ class KVStore:
         if not validate_kv(key, value):
             return ""
 
-        tstamp: int = int(time.time())
-        crc32_checksum: int = zlib.crc32(str(value).encode("utf-8"))
-
-        kv_header = KVHeader(
-            checksum=crc32_checksum,
-            timestamp=tstamp,
-            expirey=(tstamp + expirey) if expirey > 0 else 0,
-            key_sz=len(str(key)),
-            value_sz=len(str(value)),
+        self._set_key(
+            key=key,
+            val=value,
+            expirey=expirey,
         )
-
-        sz, data = KVData(header=kv_header, key=key, value=value).encode_kv()
-
-        self._write(data)
-
-        kv_entry: KVEntry = KVEntry(timestamp=tstamp, pos=self.write_pos, size=sz)
-
-        self.key_dir[key] = kv_entry
-        self.write_pos += sz
 
     def get(self, key: KeyType) -> str:
         """
@@ -92,12 +78,42 @@ class KVStore:
         args:
             key : key to be deleted
         """
-        return self.set(key, "")
+        self._set_key(
+            key=key,
+            val=TOMBSTONE,
+            expirey=int(time.time()),
+            mark_delete=True,
+        )
 
     def close(self) -> None:
         self.file.flush()
         fsync(self.file.fileno())
         self.file.close()
+
+    def _set_key(
+        self, key: KeyType, val: ValueType, expirey: int = 0, mark_delete: bool = False
+    ) -> None:
+        """
+        set a value for key, persist to disk. when a key is deleted, a tombstone
+        value is written by calling this function
+        """
+        tstamp: int = int(time.time())
+        crc32_checksum: int = zlib.crc32(str(val).encode("utf-8"))
+
+        kv_header = KVHeader(
+            checksum=crc32_checksum,
+            timestamp=tstamp,
+            expirey=(tstamp + expirey) if expirey > 0 else 0,
+            deleted=1 if mark_delete else 0,
+            key_sz=len(str(key)),
+            value_sz=len(str(val)),
+        )
+
+        sz, data = KVData(header=kv_header, key=key, value=val).encode_kv()
+        self._write(data)
+        kv_entry: KVEntry = KVEntry(timestamp=tstamp, pos=self.write_pos, size=sz)
+        self.key_dir[key] = kv_entry
+        self.write_pos += sz
 
     def _write(self, data: bytes) -> None:
         """
@@ -122,7 +138,9 @@ class KVStore:
             f.seek(0)
 
             while hdr_bytes := f.read(HEADER_SIZE):
-                chksm, tstamp, expiry, ksz, vsz = KVHeader.decode(hdr_bytes)
+                chksm, tstamp, expiry, deleted, ksz, vsz = KVHeader.decode_hdr(
+                    hdr_bytes
+                )
 
                 key_bytes = f.read(ksz)
                 key = key_bytes.decode("utf-8")

--- a/src/errors.py
+++ b/src/errors.py
@@ -1,0 +1,12 @@
+class UnsupportedTypeError(ValueError):
+    def __init__(self, value_type: type, context: str = "") -> None:
+        self.value_type = value_type
+        self.context = context
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        message = f"Unsupported type: {self.value_type.__name__}"
+        if self.context:
+            message += f" ({self.context})"
+
+        return message

--- a/src/errors.py
+++ b/src/errors.py
@@ -5,8 +5,8 @@ class UnsupportedTypeError(ValueError):
         super().__init__(self.__str__())
 
     def __str__(self) -> str:
-        message = f"Unsupported type: {self.value_type.__name__}"
+        message = f"Unsupported type: {self.value_type.__name__},"
         if self.context:
-            message += f" ({self.context})"
+            message += f" {self.context}"
 
         return message

--- a/src/format.py
+++ b/src/format.py
@@ -3,8 +3,7 @@ import struct
 import zlib
 import time
 from src.custom_types import KeyType, ValueType
-from src.utils import encode_to_str
-from src.errors import UnsupportedTypeError
+
 
 """
 ref: https://riak.com/assets/bitcask-intro.pdf
@@ -118,20 +117,7 @@ class KVData:
         returns a tuple of size of encoded bytes and byte object
         """
         hdr: bytes = self.header.encode_hdr()
-        try:
-            key: str = encode_to_str(self.key)
-        except UnsupportedTypeError as e:
-            raise UnsupportedTypeError(
-                e.value_type,
-            ) from e
-        try:
-            val: str = encode_to_str(self.value)
-        except UnsupportedTypeError as e:
-            raise UnsupportedTypeError(
-                e.value_type,
-            ) from e
-
-        data: bytes = b"".join([str.encode(key), str.encode(val)])
+        data: bytes = b"".join([str.encode(self.key), str.encode(self.value)])
         return HEADER_SIZE + len(data), hdr + data
 
     @classmethod

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 from src.custom_types import KeyType, ValueType
+from src.errors import UnsupportedTypeError
 
 
 def validate_kv(key: KeyType, value: ValueType) -> bool:
@@ -15,3 +16,17 @@ def validate_kv(key: KeyType, value: ValueType) -> bool:
         return False
 
     return True
+
+
+def encode_to_str(value) -> str:
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, (int, float)):
+        return str(value)
+    elif isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.hex()
+    else:
+        raise UnsupportedTypeError(type(value), "in encode_to_str")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,21 +1,4 @@
-from src.custom_types import KeyType, ValueType
 from src.errors import UnsupportedTypeError
-
-
-def validate_kv(key: KeyType, value: ValueType) -> bool:
-    if not isinstance(key, KeyType):
-        return False
-
-    if not isinstance(value, ValueType):
-        return False
-
-    if isinstance(key, int):
-        key = str(key)
-
-    if len(key) <= 0:
-        return False
-
-    return True
 
 
 def encode_to_str(value) -> str:
@@ -29,4 +12,4 @@ def encode_to_str(value) -> str:
         except UnicodeDecodeError:
             return value.hex()
     else:
-        raise UnsupportedTypeError(type(value), "in encode_to_str")
+        raise UnsupportedTypeError(type(value), "in encode_to_str()")

--- a/tests/test_disk_store.py
+++ b/tests/test_disk_store.py
@@ -7,6 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from src.disk_store import KVStore
 from src.custom_types import TOMBSTONE
+from src.errors import UnsupportedTypeError
 
 
 class TempStorageFile:
@@ -75,7 +76,7 @@ class TestDiskStorage(unittest.TestCase):
             "pay_rate": 75.5,
             "occupation": "Engineer",
             "hobbies": "Reading, Cycling, Hiking",
-            # "email": b"alice@example.com",
+            "email": b"alice@example.com",
             b"languages": "English, Spanish, French",
             1234: "id",
             3.14: b"PI",
@@ -85,14 +86,14 @@ class TestDiskStorage(unittest.TestCase):
             ds.set(k, v)
             val = ds.get(k)
             if isinstance(val, type(v)):
-                self.assertEqual(ds.get(k), v)
+                self.assertEqual(val, v)
             else:
                 if isinstance(v, int):
                     self.assertEqual(int(val), v)
                 elif isinstance(v, float):
                     self.assertEqual(float(val), v)
                 elif isinstance(v, bytes):
-                    self.assertEqual(val, str(v))
+                    self.assertEqual(val, v.decode("utf-8"))
                 else:
                     pass
 
@@ -152,8 +153,9 @@ class TestDiskStorage(unittest.TestCase):
 
         kvs = {"alist": [1, 2, 3], (1, 2): "tuple"}
 
-        for k, v in kvs.items():
-            ds.set(k, v)
+        with self.assertRaises(UnsupportedTypeError):
+            for k, v in kvs.items():
+                ds.set(k, v)
 
 
 if __name__ == "__main__":

--- a/tests/test_disk_store.py
+++ b/tests/test_disk_store.py
@@ -1,8 +1,12 @@
 import os
+import sys
 import tempfile
 import unittest
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from src.disk_store import KVStore
+from src.custom_types import TOMBSTONE
 
 
 class TempStorageFile:
@@ -64,6 +68,34 @@ class TestDiskStorage(unittest.TestCase):
         self.assertNotEqual(ds.get("quick"), "")
         self.assertEqual(ds.get("quick"), "black fox")
 
+        kvs = {
+            "name": "Alice",
+            "city": "New York",
+            "age": 30,
+            "pay_rate": 75.5,
+            "occupation": "Engineer",
+            "hobbies": "Reading, Cycling, Hiking",
+            # "email": b"alice@example.com",
+            b"languages": "English, Spanish, French",
+            1234: "id",
+            3.14: b"PI",
+        }
+
+        for k, v in kvs.items():
+            ds.set(k, v)
+            val = ds.get(k)
+            if isinstance(val, type(v)):
+                self.assertEqual(ds.get(k), v)
+            else:
+                if isinstance(v, int):
+                    self.assertEqual(int(val), v)
+                elif isinstance(v, float):
+                    self.assertEqual(float(val), v)
+                elif isinstance(v, bytes):
+                    self.assertEqual(val, str(v))
+                else:
+                    pass
+
         ds.close()
 
     def test_persistance(self):
@@ -110,10 +142,18 @@ class TestDiskStorage(unittest.TestCase):
 
         for k, v in kvs.items():
             ds.delete(k)
-            self.assertEqual(ds.get(k), "")
+            self.assertEqual(int(ds.get(k)), TOMBSTONE)
             self.assertNotEqual(ds.get(k), v)
 
         ds.close()
+
+    def test_UnsupportedTypeError(self):
+        ds = KVStore(self.file.path)
+
+        kvs = {"alist": [1, 2, 3], (1, 2): "tuple"}
+
+        for k, v in kvs.items():
+            ds.set(k, v)
 
 
 if __name__ == "__main__":

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,7 +1,12 @@
+import os
+import sys
 import unittest
 import time
 import random
 import uuid
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from src.format import (
     KVHeader,
     KVData,
@@ -11,25 +16,26 @@ from src.format import (
 
 class FormatTester(unittest.TestCase):
     def test_header_encoder_decoder(self) -> None:
-        chksm, tstamp, expirey, ksz, vsz = random_hdr()
+        chksm, tstamp, expirey, deleted, ksz, vsz = random_hdr()
         hdr = KVHeader(
             checksum=chksm, timestamp=tstamp, key_sz=ksz, value_sz=vsz, expirey=expirey
         )
-        data = hdr.encode()
-        c, t, e, k, v = KVHeader.decode(data)
+        data = hdr.encode_hdr()
+        c, t, e, d, k, v = KVHeader.decode_hdr(data)
 
         self.assertEqual(tstamp, t)
         self.assertEqual(ksz, k)
         self.assertEqual(vsz, v)
         self.assertEqual(chksm, c)
         self.assertEqual(expirey, e)
+        self.assertEqual(deleted, d)
 
     def test_headers(self):
         for _ in range(50):
             self.test_header_encoder_decoder()
 
     def test_kv_encoder_decoder(self) -> None:
-        chksm, tstamp, expirey, key, val, size = random_kv_entry()
+        chksm, tstamp, expirey, deleted, key, val, size = random_kv_entry()
 
         hdr = KVHeader(
             checksum=chksm,
@@ -37,6 +43,7 @@ class FormatTester(unittest.TestCase):
             key_sz=len(str(key)),
             value_sz=len(str(val)),
             expirey=expirey,
+            deleted=deleted,
         )
         sz, data = KVData(header=hdr, key=key, value=val).encode_kv()
         t, hdr, k, v = KVData.decode_kv(data)
@@ -58,6 +65,7 @@ def random_hdr():
         random_gen(0, max_int),
         int(time.time()),
         int(time.time()) + 1000,
+        0,
         random_gen(0, max_int),
         random_gen(0, max_int),
     )
@@ -68,6 +76,7 @@ def random_kv_entry():
         random.randint(0, (2**32 - 1)),
         int(time.time()),
         int(time.time()) + 1000,
+        0,
         str(uuid.uuid1()),
         str(uuid.uuid4()),
         HEADER_SIZE + len(str(uuid.uuid1())) + len(str(uuid.uuid4())),


### PR DESCRIPTION
fixes #1 
deleted values will be marked with a special value `tombstone` instead of an empty string. this makes it easy to find deleted values and periodically run compaction to save disk space.