### PR TITLE
fix: assign correct expiry value, better errors

### DIFF
--- a/tests/test_disk_store.py
+++ b/tests/test_disk_store.py
@@ -6,7 +6,6 @@ import unittest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.disk_store import KVStore
-from src.custom_types import TOMBSTONE
 from src.errors import UnsupportedTypeError
 
 
@@ -143,7 +142,7 @@ class TestDiskStorage(unittest.TestCase):
 
         for k, v in kvs.items():
             ds.delete(k)
-            self.assertEqual(int(ds.get(k)), TOMBSTONE)
+            self.assertEqual(ds.get(k), "Key deleted")
             self.assertNotEqual(ds.get(k), v)
 
         ds.close()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -16,9 +16,9 @@ from src.format import (
 
 class FormatTester(unittest.TestCase):
     def test_header_encoder_decoder(self) -> None:
-        chksm, tstamp, expirey, deleted, ksz, vsz = random_hdr()
+        chksm, tstamp, expiry, deleted, ksz, vsz = random_hdr()
         hdr = KVHeader(
-            checksum=chksm, timestamp=tstamp, key_sz=ksz, value_sz=vsz, expirey=expirey
+            checksum=chksm, timestamp=tstamp, key_sz=ksz, value_sz=vsz, expiry=expiry
         )
         data = hdr.encode_hdr()
         c, t, e, d, k, v = KVHeader.decode_hdr(data)
@@ -27,7 +27,7 @@ class FormatTester(unittest.TestCase):
         self.assertEqual(ksz, k)
         self.assertEqual(vsz, v)
         self.assertEqual(chksm, c)
-        self.assertEqual(expirey, e)
+        self.assertEqual(expiry, e)
         self.assertEqual(deleted, d)
 
     def test_headers(self):
@@ -35,14 +35,14 @@ class FormatTester(unittest.TestCase):
             self.test_header_encoder_decoder()
 
     def test_kv_encoder_decoder(self) -> None:
-        chksm, tstamp, expirey, deleted, key, val, size = random_kv_entry()
+        chksm, tstamp, expiry, deleted, key, val, size = random_kv_entry()
 
         hdr = KVHeader(
             checksum=chksm,
             timestamp=tstamp,
             key_sz=len(str(key)),
             value_sz=len(str(val)),
-            expirey=expirey,
+            expiry=expiry,
             deleted=deleted,
         )
         sz, data = KVData(header=hdr, key=key, value=val).encode_kv()


### PR DESCRIPTION
fixes #8 
- assigns correct expiry value for tombstones
- `get(key)` method proper error messages [Key deleted / Key expired / Invalid / Corrupt]